### PR TITLE
Fix various issues with NintendoSwitchBackend

### DIFF
--- a/HAL/pico/src/comms/NintendoSwitchBackend.cpp
+++ b/HAL/pico/src/comms/NintendoSwitchBackend.cpp
@@ -2,6 +2,7 @@
 
 #include "core/CommunicationBackend.hpp"
 #include "core/state.hpp"
+#include "util/analog_filters.hpp"
 
 #include <Adafruit_TinyUSB.h>
 #include <TUCompositeHID.hpp>
@@ -48,9 +49,13 @@
         HID_REPORT_SIZE    ( 8                                      ) ,\
         HID_REPORT_COUNT   ( 4                                      ) ,\
         HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-        /* Some output from the host idk */ \
+        /* Some random vendor input idk */ \
         HID_USAGE_PAGE_N   ( HID_USAGE_PAGE_VENDOR, 2               ) ,\
         HID_USAGE          ( 0x20                                   ) ,\
+        HID_REPORT_COUNT   ( 1                                      ) ,\
+        HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+        /* Some output from the host idk */ \
+        0x0A, 0x21, 0x26, \
         HID_REPORT_COUNT   ( 8                                      ) ,\
         HID_OUTPUT         ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
     HID_COLLECTION_END
@@ -127,10 +132,10 @@ void NintendoSwitchBackend::SendReport() {
     _report.home = _outputs.home;
 
     // Analog outputs
-    _report.lx = (_outputs.leftStickX - 128) * 1.25 + 128;
-    _report.ly = 255 - ((_outputs.leftStickY - 128) * 1.25 + 128);
-    _report.rx = (_outputs.rightStickX - 128) * 1.25 + 128;
-    _report.ry = 255 - ((_outputs.rightStickY - 128) * 1.25 + 128);
+    _report.lx = apply_radius(apply_deadzone(_outputs.leftStickX, 15, true), 256);
+    _report.ly = 255 - apply_radius(apply_deadzone(_outputs.leftStickY, 15, true), 256);
+    _report.rx = apply_radius(apply_deadzone(_outputs.rightStickX, 15, true), 256);
+    _report.ry = 255 - apply_radius(apply_deadzone(_outputs.rightStickY, 15, true), 256);
 
     // D-pad Hat Switch
     _report.hat =

--- a/include/util/analog_filters.hpp
+++ b/include/util/analog_filters.hpp
@@ -1,0 +1,9 @@
+#ifndef _UTIL_ANALOG_FILTERS_HPP
+#define _UTIL_ANALOG_FILTERS_HPP
+
+#include "stdlib.hpp"
+
+uint8_t apply_deadzone(uint8_t value, uint8_t deadzone, bool scale);
+uint8_t apply_radius(uint8_t value, int radius);
+
+#endif

--- a/src/util/analog_filters.cpp
+++ b/src/util/analog_filters.cpp
@@ -1,0 +1,29 @@
+#include "util/analog_filters.hpp"
+
+#include <math.h>
+
+#define SIGNUM(x) ((x > 0) - (x < 0))
+
+uint8_t apply_deadzone(uint8_t value, uint8_t deadzone, bool scale) {
+    int8_t value_signed = value - 128;
+    if (abs(value_signed) > deadzone) {
+        // If outside deadzone, must subtract deadzone from result so that axis values start from 1
+        // instead of having lower values cut off.
+        int8_t post_deadzone = value_signed - deadzone * SIGNUM(value_signed);
+        // If a radius value is passed in, scale up the values linearly so that the same effective
+        // value is given on the rim.
+        if (scale) {
+            int8_t sign = SIGNUM(post_deadzone);
+            int8_t post_scaling = min(127, abs(post_deadzone) * 128.0 / (128 - deadzone)) * sign;
+            return post_scaling + 128;
+        }
+        return post_deadzone + 128;
+    }
+    return 128;
+}
+
+uint8_t apply_radius(uint8_t value, int radius) {
+    int8_t value_signed = value - 128;
+    int8_t sign = SIGNUM(value_signed);
+    return min(127, (int)(abs(value_signed) * radius / 128.0)) * sign + 128;
+}


### PR DESCRIPTION
NintendoSwitchBackend had several issues. Firstly, I messed up the descriptor, which was way this comms backend didn't work on PC. Secondly, because the Nintendo Switch apparently applies a deadzone and scaling to GameCube controller analog stick inputs, it was necessary to reverse engineer this scaling and replicate it in NintendoSwitchBackend so that we scale the inputs before sending them to the console, in the same way that the Switch would scale them after receiving them. Until now I have been using a naive multiplication which was not close enough to the actual formula to prevent input issues manifesting when using the Ultimate mode. Thanks to Zeronia, we have much more data now and I have been able to reverse engineer the scaling formula to get one that matches almost exactly. The only remaining considerations are that the GameCube controller C-Stick is apparently scaled differently to the left analog stick, and that I have only implemented a basic square deadzone rather than a circular deadzone. It is yet to be seen whether these things will cause any input inconsistencies in existing controller modes.